### PR TITLE
Fix historical data retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.3 - November 17, 2025
+* Bug Fix: Querying appUsageData with previous dates returns a type error of converting long to int. Switched appUsageData to take in a Number rather than int for start/end milliseconds.
+* Bug Fix: Querying appUsageData with previous dates that have no screen time will return the data from the most recent previous date that has data rather than returning zero. Now, instead of returning all data (previous non-zero day if zero), filter down query results to those specific to that date.
+
 ## 0.10.2 - May 1, 2025
 * Handle same action when request permission app usage, accessibility settings, and draw overlay to request family controls
 * Handle same action when check permission app usage, accessibility settings, and draw overlay to check family controls

--- a/android/src/main/kotlin/com/solusibejo/screen_time/ScreenTimeMethod.kt
+++ b/android/src/main/kotlin/com/solusibejo/screen_time/ScreenTimeMethod.kt
@@ -371,13 +371,13 @@ object ScreenTimeMethod {
             val queryResult = usageStatsManager.queryUsageStats(
                 interval.type, start, end
             )
-            if(packagesName != null){
-                val result = queryResult.filter { it.packageName in packagesName }
-                stats.addAll(result)
+            val filtered = queryResult.filter { stat ->
+                val withinWindow = stat.lastTimeUsed in start until end
+                val packageMatch = packagesName?.contains(stat.packageName) ?: true
+                withinWindow && packageMatch
             }
-            else{
-                stats.addAll(queryResult)
-            }
+
+            stats.addAll(filtered)
 
             val usageMap = ArrayList<Map<String, Any>>()
 

--- a/android/src/main/kotlin/com/solusibejo/screen_time/ScreenTimeMethod.kt
+++ b/android/src/main/kotlin/com/solusibejo/screen_time/ScreenTimeMethod.kt
@@ -371,13 +371,13 @@ object ScreenTimeMethod {
             val queryResult = usageStatsManager.queryUsageStats(
                 interval.type, start, end
             )
-            val filtered = queryResult.filter { stat ->
-                val withinWindow = stat.lastTimeUsed in start until end
-                val packageMatch = packagesName?.contains(stat.packageName) ?: true
-                withinWindow && packageMatch
+            if(packagesName != null){
+                val result = queryResult.filter { it.packageName in packagesName }
+                stats.addAll(result)
             }
-
-            stats.addAll(filtered)
+            else{
+                stats.addAll(queryResult)
+            }
 
             val usageMap = ArrayList<Map<String, Any>>()
 

--- a/android/src/main/kotlin/com/solusibejo/screen_time/ScreenTimeMethod.kt
+++ b/android/src/main/kotlin/com/solusibejo/screen_time/ScreenTimeMethod.kt
@@ -371,13 +371,14 @@ object ScreenTimeMethod {
             val queryResult = usageStatsManager.queryUsageStats(
                 interval.type, start, end
             )
-            if(packagesName != null){
-                val result = queryResult.filter { it.packageName in packagesName }
-                stats.addAll(result)
+            
+            val filtered = queryResult.filter { stat ->
+                val withinWindow = stat.lastTimeUsed in start until end
+                val packageMatch = packagesName?.contains(stat.packageName) ?: true
+                withinWindow && packageMatch
             }
-            else{
-                stats.addAll(queryResult)
-            }
+
+            stats.addAll(filtered)
 
             val usageMap = ArrayList<Map<String, Any>>()
 

--- a/android/src/main/kotlin/com/solusibejo/screen_time/ScreenTimePlugin.kt
+++ b/android/src/main/kotlin/com/solusibejo/screen_time/ScreenTimePlugin.kt
@@ -108,8 +108,8 @@ class ScreenTimePlugin: FlutterPlugin, MethodCallHandler, EventChannel.StreamHan
       }
       MethodName.appUsageData -> {
         val args = call.arguments as Map<String, Any?>
-        val startTimeInMillisecond = args[Argument.startTimeInMillisecond] as Int?
-        val endTimeInMillisecond = args[Argument.endTimeInMillisecond] as Int?
+        val startTimeInMillisecond = args[Argument.startTimeInMillisecond] as Number?
+        val endTimeInMillisecond = args[Argument.endTimeInMillisecond] as Number?
         val usageInterval = args[Argument.interval] as String?
             ?: UsageInterval.DAILY.name.lowercase()
         val packagesName = args[Argument.packagesName] as List<*>?

--- a/android/src/main/kotlin/com/solusibejo/screen_time/ScreenTimePlugin.kt
+++ b/android/src/main/kotlin/com/solusibejo/screen_time/ScreenTimePlugin.kt
@@ -108,8 +108,8 @@ class ScreenTimePlugin: FlutterPlugin, MethodCallHandler, EventChannel.StreamHan
       }
       MethodName.appUsageData -> {
         val args = call.arguments as Map<String, Any?>
-        val startTimeInMillisecond = args[Argument.startTimeInMillisecond] as Number?
-        val endTimeInMillisecond = args[Argument.endTimeInMillisecond] as Number?
+        val startTimeInMillisecond = args[Argument.startTimeInMillisecond] as Int?
+        val endTimeInMillisecond = args[Argument.endTimeInMillisecond] as Int?
         val usageInterval = args[Argument.interval] as String?
             ?: UsageInterval.DAILY.name.lowercase()
         val packagesName = args[Argument.packagesName] as List<*>?

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.3"
+    version: "1.3.2"
   file:
     dependency: transitive
     description:
@@ -107,26 +107,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "11.0.2"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.10"
+    version: "3.0.9"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -197,7 +197,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.10.2"
+    version: "0.10.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -255,18 +255,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.4"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.1.4"
   vm_service:
     dependency: transitive
     description:
@@ -292,5 +292,5 @@ packages:
     source: hosted
     version: "3.0.4"
 sdks:
-  dart: ">=3.8.0-0 <4.0.0"
+  dart: ">=3.7.2 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   file:
     dependency: transitive
     description:
@@ -107,26 +107,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -197,7 +197,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.10.0"
+    version: "0.10.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -255,18 +255,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.6"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -292,5 +292,5 @@ packages:
     source: hosted
     version: "3.0.4"
 sdks:
-  dart: ">=3.7.2 <4.0.0"
+  dart: ">=3.8.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   file:
     dependency: transitive
     description:
@@ -107,26 +107,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -197,7 +197,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.10.0"
+    version: "0.10.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -255,18 +255,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.6"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -292,5 +292,5 @@ packages:
     source: hosted
     version: "3.0.4"
 sdks:
-  dart: ">=3.7.2 <4.0.0"
+  dart: ">=3.8.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: screen_time
 description: The Screen Time is a set of tools that lets developers create apps that help users manage their device usage and time.
-version: 0.10.2
+version: 0.10.3
 homepage: https://solusibejo.com
 repository: https://github.com/chandrabezzo/screen_time
 issue_tracker: https://github.com/chandrabezzo/screen_time/issues


### PR DESCRIPTION
Bug Fix: Querying appUsageData with previous dates returns a type error of converting long to int. 
- Switched plugin to take in a Number rather than int for start/end milliseconds

Bug Fix: Querying appUsageData with previous dates that have no screen time will return the data from the most recent previous date that has data rather than returning zero.
- Instead of returning all data (previous non-zero day if zero), filter down query results to those specific to that date. 